### PR TITLE
Append sequence on BoolSequence with boolean value (#247)

### DIFF
--- a/src/geouned/GEOUNED/utils/boolean_function.py
+++ b/src/geouned/GEOUNED/utils/boolean_function.py
@@ -43,6 +43,12 @@ class BoolSequence:
         - A BoolSequence object
         - An integer value
         - A Boolean value"""
+
+        if type(self.elements) is bool:
+            if (self.elements and self.operator == "AND") or (not self.elements and self.operator == "OR"):
+                self.assign(seq)
+            return
+
         for s in seq:
             if type(s) is int:
                 level = -1


### PR DESCRIPTION
If you are a first-time contributor to GEOUNED, please read our contributing guidelines:
https://github.com/GEOUNED-org/GEOUNED/blob/main/CONTRIBUTING.md

# Description

Fix the issue when a sequence is added to a BoolSequence instance with a boolean value
Should fix the CI testing fail. of PR#246

# Fixes issue

Please link to any issues that this PR fixes

# Checklist

- [ ] I'm making a PR from a feature branch on my fork into GEOUNED-org/GEOUNED/dev branch
- [ ] I have followed [PEP8 style guide]([url](https://peps.python.org/pep-0008/)) for Python or run a formatter such as [black]([url](https://github.com/psf/black)) or [ruff format]([url](https://github.com/astral-sh/ruff)) on my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
